### PR TITLE
Add Dockerfile and basic instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM google/dart-runtime:1
+
+WORKDIR /app
+
+ADD pubspec.* /app/
+RUN pub get
+ADD . /app
+RUN pub get --offline
+
+EXPOSE 8080
+
+CMD []
+ENTRYPOINT ["pub", "serve", "--hostname=0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -24,3 +24,10 @@ Note: You will need to drop in Firebase details in the firebase_client.dart file
 pub get
 pub serve
 ```
+
+# Running the app with Docker
+
+```bash
+docker build -t vybor .
+docker run -p 8080:8080 vybor
+```


### PR DESCRIPTION
This allows you to run the application via Docker, and includes commands in the readme file. I wasn't able to connect to Firebase with my own credentials, but that could be simply because I know nothing about Firebase.

However, it acted exactly as the live demo site does, so maybe the Firebase module is out of date or something. I don't know, I don't know anything about Dart.